### PR TITLE
Fix ensure that executeWhenUnresponsive is resolved when all callbacks are executed.

### DIFF
--- a/src/execute-when-unresponsive.js
+++ b/src/execute-when-unresponsive.js
@@ -15,7 +15,7 @@ const createTask = (fn, timeout) => {
         .then(fn)
         .then(() => { isRunning = false; })
         .catch(() => { isRunning = false; })
-        .then(resolve)
+        .then(resolve);
     }, parseFloat(timeout) * 1000);
   });
 

--- a/src/execute-when-unresponsive.js
+++ b/src/execute-when-unresponsive.js
@@ -29,19 +29,21 @@ const createTask = (fn, timeout) => {
 const buildExecutionSchedule = (executionList) => Object.keys(executionList)
   .map((duration) => createTask(executionList[duration], duration));
 
-const clearExecutionSchedule = (schedule) => {
-  schedule
-    .filter((task) => !task.isRunning())
-    .map((task) => {
-      clearTimeout(task.getTimeoutId())
-      return task;
-    });
+const clearIdleTasks = (schedule) => schedule
+  .filter((task) => !task.isRunning())
+  .map((task) => clearTimeout(task.getTimeoutId()));
 
+const waitForRunningTasks = (schedule) => {
   const pendingPromises = schedule
     .filter((task) => task.isRunning())
     .map((task) => task.getPromise());
 
   return Promise.all(pendingPromises);
+};
+
+const clearExecutionSchedule = (schedule) => {
+  clearIdleTasks(schedule);
+  return waitForRunningTasks(schedule);
 };
 
 export const executeWhenUnresponsive = (executionList) => (fn) => (arg) => {

--- a/src/execute-when-unresponsive.js
+++ b/src/execute-when-unresponsive.js
@@ -4,23 +4,45 @@ import {
 } from './index';
 
 const createTask = (fn, timeout) => {
-  let timeoutId = setTimeout(() => {
-    Promise.resolve()
-      .then(fn)
-      .then(() => { timeoutId = void 0 })
-      .catch(() => { timeoutId = void 0 });
-  }, parseFloat(timeout * 1000));
+  let timeoutId = void 0;
+  let isRunning = false;
+
+  const promise = new Promise((resolve) => {
+    timeoutId = setTimeout(() => {
+      isRunning = true;
+
+      Promise.resolve()
+        .then(fn)
+        .then(() => { isRunning = false; })
+        .catch(() => { isRunning = false; })
+        .then(resolve)
+    }, parseFloat(timeout) * 1000);
+  });
 
   return {
+    getPromise: () => promise,
     getTimeoutId: () => timeoutId,
+    isRunning: () => !!isRunning,
   };
 };
 
 const buildExecutionSchedule = (executionList) => Object.keys(executionList)
   .map((duration) => createTask(executionList[duration], duration));
 
-const clearExecutionSchedule = (schedule) =>
-  schedule.forEach((task) => clearTimeout(task.getTimeoutId()));
+const clearExecutionSchedule = (schedule) => {
+  schedule
+    .filter((task) => !task.isRunning())
+    .map((task) => {
+      clearTimeout(task.getTimeoutId())
+      return task;
+    });
+
+  const pendingPromises = schedule
+    .filter((task) => task.isRunning())
+    .map((task) => task.getPromise());
+
+  return Promise.all(pendingPromises);
+};
 
 export const executeWhenUnresponsive = (executionList) => (fn) => (arg) => {
   const schedule = buildExecutionSchedule(executionList);

--- a/src/execute-when-unresponsive.js
+++ b/src/execute-when-unresponsive.js
@@ -3,14 +3,20 @@ import {
   rethrowError,
 } from './index';
 
-const scheduleExecution = (fn, timeout) =>
-  setTimeout(fn, parseFloat(timeout * 1000));
+
+const createTask = (fn, timeout) => {
+  let timeoutId = setTimeout(fn, parseFloat(timeout * 1000));
+  return {
+    getTimeoutId: () => timeoutId,
+  };
+};
+
 
 const buildExecutionSchedule = (executionList) => Object.keys(executionList)
-  .map((duration) => scheduleExecution(executionList[duration], duration));
+  .map((duration) => createTask(executionList[duration], duration));
 
 const clearExecutionSchedule = (schedule) =>
-  schedule.forEach((timeoutId) => clearTimeout(timeoutId));
+  schedule.forEach((task) => clearTimeout(task.getTimeoutId()));
 
 export const executeWhenUnresponsive = (executionList) => (fn) => (arg) => {
   const schedule = buildExecutionSchedule(executionList);

--- a/src/execute-when-unresponsive.js
+++ b/src/execute-when-unresponsive.js
@@ -3,14 +3,18 @@ import {
   rethrowError,
 } from './index';
 
-
 const createTask = (fn, timeout) => {
-  let timeoutId = setTimeout(fn, parseFloat(timeout * 1000));
+  let timeoutId = setTimeout(() => {
+    Promise.resolve()
+      .then(fn)
+      .then(() => { timeoutId = void 0 })
+      .catch(() => { timeoutId = void 0 });
+  }, parseFloat(timeout * 1000));
+
   return {
     getTimeoutId: () => timeoutId,
   };
 };
-
 
 const buildExecutionSchedule = (executionList) => Object.keys(executionList)
   .map((duration) => createTask(executionList[duration], duration));

--- a/src/ignore-return-for.js
+++ b/src/ignore-return-for.js
@@ -1,5 +1,3 @@
-export const ignoreReturnFor = (fn) => (arg) => {
-  fn(arg);
-  return arg;
-};
-
+export const ignoreReturnFor = (fn) => (arg) => Promise.resolve()
+  .then(() => fn(arg))
+  .then(() => arg);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -188,24 +188,21 @@ describe('executeWhenUnresponsive', () => {
       });
   });
 
-  xit('waits until all schedules are resolved before resolving promise', () => {
+  it('waits until all schedules are resolved before resolving promise', () => {
     const callOrder = [];
 
     const longLastingPromise = () =>
-      new Promise((resolve) => setTimeout(resolve, 20));
+      new Promise((resolve) => setTimeout(resolve, 30));
 
     const displayErrors = executeWhenUnresponsive({
-      0.1: () => longLastingPromise().then(() => callOrder.push('errorFn')),
+      0.01: () => longLastingPromise().then(() => { callOrder.push('errorFn')}),
     });
 
     const apiCall = () => longLastingPromise();
-
     return Promise.resolve()
       .then(displayErrors(apiCall))
-      .then(() => delay(0.5))
       .then(() => callOrder.push('apiCall'))
       .then(() => {
-        console.log(callOrder);
         assertThat(callOrder[0], equalTo('errorFn'));
         assertThat(callOrder[1], equalTo('apiCall'));
       });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -195,7 +195,7 @@ describe('executeWhenUnresponsive', () => {
       new Promise((resolve) => setTimeout(resolve, 30));
 
     const displayErrors = executeWhenUnresponsive({
-      0.01: () => longLastingPromise().then(() => { callOrder.push('errorFn')}),
+      0.01: () => longLastingPromise().then(() => { callOrder.push('errorFn'); }),
     });
 
     const apiCall = () => longLastingPromise();

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -187,4 +187,27 @@ describe('executeWhenUnresponsive', () => {
         assertThat(fnAfter10msWasCalled, equalTo(false));
       });
   });
+
+  xit('waits until all schedules are resolved before resolving promise', () => {
+    const callOrder = [];
+
+    const longLastingPromise = () =>
+      new Promise((resolve) => setTimeout(resolve, 20));
+
+    const displayErrors = executeWhenUnresponsive({
+      0.1: () => longLastingPromise().then(() => callOrder.push('errorFn')),
+    });
+
+    const apiCall = () => longLastingPromise();
+
+    return Promise.resolve()
+      .then(displayErrors(apiCall))
+      .then(() => delay(0.5))
+      .then(() => callOrder.push('apiCall'))
+      .then(() => {
+        console.log(callOrder);
+        assertThat(callOrder[0], equalTo('errorFn'));
+        assertThat(callOrder[1], equalTo('apiCall'));
+      });
+  });
 });


### PR DESCRIPTION
Ensure that executeWhenUnresponsive finishes all running callbacks before resolving. V0.2.0 could lead to a bug where one of the callbacks calls a function after the original function was executed.

https://www.draw.io/?chrome=0&lightbox=1&edit=https%3A%2F%2Fwww.draw.io%2F%23G0B8eYyWESsAkIaXg5NlFYMHFhcVE&nav=1#G0B8eYyWESsAkIaXg5NlFYMHFhcVE 