### PR TITLE
Let sequence respond a new function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-frites",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A promis utility library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -6,4 +6,4 @@ const _sequence = (arg, ...fns) => {
     .then((newArg) => _sequence(newArg, ...rest));
 };
 
-export const sequence = (...fns) => _sequence(void 0, ...fns);
+export const sequence = (...fns) => () => _sequence(void 0, ...fns);

--- a/src/sequence.spec.js
+++ b/src/sequence.spec.js
@@ -4,22 +4,22 @@ import { sequence } from './index';
 describe('sequence', () => {
   it('calls given fns sequentially', () => {
     let secondWasCalled = false;
-    return sequence(
-      () => assertThat(secondWasCalled, equalTo(false)),
-      () => { secondWasCalled = true; },
-    );
+    return Promise.resolve()
+      .then(sequence(
+        () => assertThat(secondWasCalled, equalTo(false)),
+        () => { secondWasCalled = true; },
+      ));
   });
 
-  it('AND passes arguments to the next fn', () => {
-    return sequence(
+  it('AND passes arguments to the next fn', () => Promise.resolve()
+    .then(sequence(
       () => 'my argument',
       (myArgument) => assertThat(myArgument, equalTo('my argument')),
-    );
-  });
+    )));
 
-  it('AND returns last argument in chain', () => {
-    return sequence(
+  it('AND returns last argument in chain', () => Promise.resolve()
+    .then(sequence(
       () => 'my argument',
-    ).then((myArgument) => assertThat(myArgument, equalTo('my argument')));
-  });
+    ))
+    .then((myArgument) => assertThat(myArgument, equalTo('my argument'))));
 });


### PR DESCRIPTION
This allows an easier chaining.
```js
Promise.resolve()
  .then(sequence(...analyticsEvents))
  .then((userRedirectedToAppResult) => console.log('All items have been saved.'));

// instead of 
Promise.resolve()
  .then(() => sequence(...analyticsEvents))
  .then((userRedirectedToAppResult) => console.log('All items have been saved.'));
